### PR TITLE
[FEAT] 우체통 기능에 무한스크롤 추가

### DIFF
--- a/src/main/java/depth/mvp/ieum/domain/letter/application/MailBoxService.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/application/MailBoxService.java
@@ -7,7 +7,11 @@ import depth.mvp.ieum.domain.letter.dto.MailBoxDetailsRes;
 import depth.mvp.ieum.domain.letter.dto.MailBoxRes;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -16,20 +20,26 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class MailBoxService {
 
     private final LetterRepository letterRepository;
 
     // 우체통 - 받은 편지 리스트로 조회
     // 안 읽은 편지
-    public List<MailBoxRes> getUnreadLetters(Long userId) {
-        List<Letter> unreadLetters = letterRepository.findByReceiver_IdAndIsReadAndLetterType(userId, false, LetterType.SENT);
+    @Transactional
+    public List<MailBoxRes> getUnreadLetters(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Letter> unreadLettersPage = letterRepository.findByReceiver_IdAndIsReadAndLetterType(userId, false, LetterType.SENT, pageable);
+        List<Letter> unreadLetters = unreadLettersPage.getContent();
         return convertLettersToMailBoxResList(unreadLetters);
     }
 
-    // 읽은 편지
-    public List<MailBoxRes> getReadLetters(Long userId) {
-        List<Letter> readLetters = letterRepository.findByReceiver_IdAndIsReadAndLetterType(userId, true, LetterType.SENT);
+    @Transactional
+    public List<MailBoxRes> getReadLetters(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Letter> readLettersPage = letterRepository.findByReceiver_IdAndIsReadAndLetterType(userId, true, LetterType.SENT, pageable);
+        List<Letter> readLetters = readLettersPage.getContent();
         return convertLettersToMailBoxResList(readLetters);
     }
 

--- a/src/main/java/depth/mvp/ieum/domain/letter/domain/repository/LetterRepository.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/domain/repository/LetterRepository.java
@@ -2,12 +2,14 @@ package depth.mvp.ieum.domain.letter.domain.repository;
 
 import depth.mvp.ieum.domain.letter.domain.Letter;
 import depth.mvp.ieum.domain.letter.domain.LetterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
 
-    List<Letter> findByReceiver_IdAndIsReadAndLetterType(Long userId, boolean isRead, LetterType letterType);
+    Page<Letter> findByReceiver_IdAndIsReadAndLetterType(Long userId, boolean isRead, LetterType letterType, Pageable pageable);
     List<Letter> findBySender_IdAndLetterType(Long userId, LetterType letterType);
 }

--- a/src/main/java/depth/mvp/ieum/domain/letter/presentation/MailBoxController.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/presentation/MailBoxController.java
@@ -10,10 +10,7 @@ import depth.mvp.ieum.global.config.security.token.UserPrincipal;
 import depth.mvp.ieum.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,8 +22,12 @@ public class MailBoxController {
     private final MailBoxService mailBoxService;
 
     @GetMapping
-    public ResponseEntity<?> getUnreadLetters(@CurrentUser UserPrincipal userPrincipal) {
-        List<MailBoxRes> mailBoxRes = mailBoxService.getUnreadLetters(userPrincipal.getId());
+    public ResponseEntity<?> getUnreadLetters(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        List<MailBoxRes> mailBoxRes = mailBoxService.getUnreadLetters(userPrincipal.getId(), page, size);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
@@ -37,8 +38,12 @@ public class MailBoxController {
     }
 
     @GetMapping("/read")
-    public ResponseEntity<?> getReadLetters(@CurrentUser UserPrincipal userPrincipal) {
-        List<MailBoxRes> mailBoxRes = mailBoxService.getReadLetters(userPrincipal.getId());
+    public ResponseEntity<?> getReadLetters(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        List<MailBoxRes> mailBoxRes = mailBoxService.getReadLetters(userPrincipal.getId(), page, size);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
- [x] 편지 조회 기능에 무한스크롤 추가

## To Reviewers 💬
- controller 코드에서 변경된 점은 page(default 0), size(default 6)의 값을 파라미터로 전달합니다. service에서는 해당 부분을 추가했습니다.
 `Pageable pageable = PageRequest.of(page, size);
        Page<Letter> unreadLettersPage = letterRepository.findByReceiver_IdAndIsReadAndLetterType(userId, false, LetterType.SENT, pageable);
        List<Letter> unreadLetters = unreadLettersPage.getContent();`
- 또한 mailService에서 지연로딩 오류가 발생해 transactional 어노테이션을 적절히 추가하여 해결했습니다.


## Reference 🔬 
- https://velog.io/@do_ng_iill/Spring-Pagination
- https://wbluke.tistory.com/18
