### PR TITLE
[FIX]: 닉네임 추천 api 예외 처리, 이메일 인증 시 이메일 DB 조회

### DIFF
--- a/src/main/java/depth/mvp/ieum/domain/auth/application/AuthCheckService.java
+++ b/src/main/java/depth/mvp/ieum/domain/auth/application/AuthCheckService.java
@@ -1,8 +1,11 @@
 package depth.mvp.ieum.domain.auth.application;
 
+import depth.mvp.ieum.domain.gpt.application.ChatGptService;
+import depth.mvp.ieum.domain.gpt.dto.RecommendRes;
 import depth.mvp.ieum.domain.user.domain.User;
 import depth.mvp.ieum.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +14,11 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class AuthCheckService {
 
     private final UserRepository userRepository;
+    private final ChatGptService chatGptService;
 
     /**
      * 이메일 중복 체크
@@ -33,5 +38,15 @@ public class AuthCheckService {
     public boolean nicknameCheck(String nickname) {
         Optional<User> user = userRepository.findByNickname(nickname);
         return user.isEmpty();
+    }
+
+    // 닉네임 추천 받기
+    public RecommendRes recommendNickname() {
+        RecommendRes nicknameList = chatGptService.recommendNickname();
+        log.info(String.valueOf(nicknameList.getNickname().size()));
+        if (nicknameList.getNickname().size() != 5) {
+            chatGptService.recommendNickname();
+        }
+        return nicknameList;
     }
 }

--- a/src/main/java/depth/mvp/ieum/domain/auth/presentation/AuthCheckController.java
+++ b/src/main/java/depth/mvp/ieum/domain/auth/presentation/AuthCheckController.java
@@ -59,7 +59,7 @@ public class AuthCheckController {
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(chatGptService.recommendNickname())
+                .information(authCheckService.recommendNickname())
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/depth/mvp/ieum/domain/verify/application/VerifyService.java
+++ b/src/main/java/depth/mvp/ieum/domain/verify/application/VerifyService.java
@@ -1,6 +1,7 @@
 package depth.mvp.ieum.domain.verify.application;
 
 import depth.mvp.ieum.domain.mail.MailService;
+import depth.mvp.ieum.domain.user.domain.repository.UserRepository;
 import depth.mvp.ieum.domain.verify.domain.Verify;
 import depth.mvp.ieum.domain.verify.domain.repository.VerifyRepository;
 import depth.mvp.ieum.global.DefaultAssert;
@@ -20,6 +21,7 @@ public class VerifyService {
 
     private final MailService mailService;
     private final VerifyRepository verifyRepository;
+    private final UserRepository userRepository;
 
 
     /**
@@ -28,6 +30,8 @@ public class VerifyService {
      */
     @Transactional
     public void sendVerifyCode(String targetEmail) {
+
+        DefaultAssert.isTrue(userRepository.existsByEmail(targetEmail), "이메일이 올바르지 않습니다.");
 
         // mailService를 이용해 해당 이메일로 인증코드를 보낸다.
         String randomCode = mailService.sendVerifyCode(targetEmail);


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 닉네임 추천 api 예외 처리 -> 재호출
- [x] 이메일 인증 시 이메일 DB 조회

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 닉네임 추천 gpt api 응답이 가끔 이상한 형식으로 오면 빈 배열로 프론트에 전달되는 문제가 있는데, 조건문을 하나 달아서 재호출하도록 했습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
