### PR TITLE
[FIX] 임시저장 관련 오류 해결

### DIFF
--- a/src/main/java/depth/mvp/ieum/domain/letter/application/LetterGptService.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/application/LetterGptService.java
@@ -51,14 +51,15 @@ public class LetterGptService {
         DefaultAssert.isTrue(user.isPresent(), "유저가 올바르지 않습니다.");
         User findUser = user.get();
 
-        // 수신인은 gpt이므로 receiver는 null, isRead는 true로 생성
-        // 추가) 발송되는 편지이므로 LetterType.SENT 지정
+        // 수신인은 gpt이므로 receiver는 null, isRead는 true로 생성, isGPT true로 생성
+        // 추가) LetterType.SENT 지정
         Letter letter = Letter.builder()
                 .sender(findUser)
                 .title(letterReq.getTitle())
                 .contents(letterReq.getContents())
                 .envelopType(letterReq.getEnvelopType())
                 .letterType(LetterType.SENT)
+                .isGPT(true)
                 .isRead(true)
                 .build();
 
@@ -80,6 +81,7 @@ public class LetterGptService {
                 .contents(letterReq.getContents())
                 .envelopType(letterReq.getEnvelopType())
                 .letterType(LetterType.SENT)
+                .isGPT(true)
                 .isRead(true)
                 .build();
 
@@ -153,6 +155,7 @@ public class LetterGptService {
                     .contents(letterRes.getData())
                     .envelopType(letterFromUser.getEnvelopType())
                     .letterType(LetterType.SENT)   // LetterType.SENT 지정
+                    .isGPT(true)
                     .isRead(false)
                     .build();
             letterRepository.save(letterFromGpt);
@@ -202,6 +205,7 @@ public class LetterGptService {
                     .contents(letterRes.getData())
                     .envelopType(letterFromUser.getEnvelopType())
                     .letterType(LetterType.SENT)   // LetterType.SENT 지정
+                    .isGPT(true)
                     .isRead(false)
                     .build();
             letterRepository.save(letterFromGpt);

--- a/src/main/java/depth/mvp/ieum/domain/letter/application/LetterService.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/application/LetterService.java
@@ -45,6 +45,7 @@ public class LetterService {
                     .contents(letterReq.getContents())
                     .envelopType(letterReq.getEnvelopType())
                     .isRead(false)
+                    .isGPT(false)
                     .letterType(LetterType.SENT)
                     .build();
             letterRepository.save(letter);

--- a/src/main/java/depth/mvp/ieum/domain/letter/domain/Letter.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/domain/Letter.java
@@ -36,6 +36,8 @@ public class Letter extends BaseEntity {
 
     private boolean isRead;
 
+    private boolean isGPT;   // 챗지피티가 보낸 편지, 챗지피티한테 보낸 편지일 경우 true
+
     @Enumerated(EnumType.STRING)
     private LetterType letterType;
 

--- a/src/main/java/depth/mvp/ieum/domain/letter/domain/repository/LetterRepository.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/domain/repository/LetterRepository.java
@@ -14,4 +14,8 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
     List<Letter> findBySender_IdAndLetterType(Long userId, LetterType letterType);
 
     List<Letter> findBySender_IdOrReceiver_Id(Long sender_id, Long receiver_id);
+
+    List<Letter> findBySender_IdAndIsGPTAndLetterType(Long userId, boolean b, LetterType temp);
+
+    List<Letter> findBySender_IdAndReceiver_IdAndLetterType(Long senderId, Long receiverId, LetterType temp);
 }

--- a/src/main/java/depth/mvp/ieum/domain/letter/presentation/LetterController.java
+++ b/src/main/java/depth/mvp/ieum/domain/letter/presentation/LetterController.java
@@ -69,8 +69,8 @@ public class LetterController {
 
     // 답장
     @GetMapping("/temp-reply")
-    public ResponseEntity<?> getReplyTempLetters(@CurrentUser UserPrincipal userPrincipal) {
-        List<TempLetterRes> tempLetterRes = tempLetterService.getReplyTempLetters(userPrincipal.getId());
+    public ResponseEntity<?> getReplyTempLetters(@CurrentUser UserPrincipal userPrincipal, @RequestParam Long letterId) {
+        List<TempLetterRes> tempLetterRes = tempLetterService.getReplyTempLetters(userPrincipal.getId(), letterId);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
- [x] 답장 - 임시저장 시 GPT api가 대상자인 경우 저장 안 되는 오류 해결
- [x] 편지 상세보기 - 답장 - 임시저장된 편지 목록 불러오기 관련 문제 해결
- [x] 임시저장 - 신규 편지/GPT api에게 답장 구분을 위해 isGPT 컬럼 생성 및 관련 로직 수정

## To Reviewers 💬
- 편지 상세보기 - 답장 - 임시저장된 편지 목록 조회 수정 과정에서 요청 값이 변경돼서 api 명세서에 추가해두었습니다! 
- isGPT의 경우 사용자가 챗지피티에게 편지를 보내거나, 챗지피티가 사용자에게 편지를 보내는 경우 true로 설정했습니다. 추가로 챗지피티에게 발송/답장, 챗지피티가 답장하는 메소드에 isGPT true로 지정해뒀습니다.

## Reference 🔬 
- 
